### PR TITLE
Level 2 Integration

### DIFF
--- a/Gameheads-SAP-2024/Assets/Prefabs/Lose Screen.prefab
+++ b/Gameheads-SAP-2024/Assets/Prefabs/Lose Screen.prefab
@@ -324,7 +324,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: GameManager, Assembly-CSharp
-        m_MethodName: startGame
+        m_MethodName: resetScene
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Gameheads-SAP-2024/Assets/Scenes/Revamping Level 1.unity
+++ b/Gameheads-SAP-2024/Assets/Scenes/Revamping Level 1.unity
@@ -92038,6 +92038,7 @@ MonoBehaviour:
   lossScore: {fileID: 9936204}
   pauseCanvas: {fileID: 1621293674}
   boulder: {fileID: 1892131989}
+  levelNumber: 1
 --- !u!4 &2141276440
 Transform:
   m_ObjectHideFlags: 0

--- a/Gameheads-SAP-2024/Assets/Scripts/Managers/LevelUIManager.cs
+++ b/Gameheads-SAP-2024/Assets/Scripts/Managers/LevelUIManager.cs
@@ -14,6 +14,8 @@ public class LevelUIManager : MonoBehaviour
     [SerializeField] TextMeshProUGUI lossScore;
     [SerializeField] GameObject pauseCanvas;
     [SerializeField] Boulder boulder;
+    [SerializeField] int levelNumber;
+
     private GameObject player;
     private bool isPaused;
 
@@ -75,7 +77,13 @@ public class LevelUIManager : MonoBehaviour
         {
             waitTime += 1 * Time.deltaTime;
         }
-        SceneManager.LoadScene("Final Cutscene");
+        if (levelNumber == 1)
+        {
+            SceneManager.LoadScene("Proto Level 2")
+        }
+        else if (levelNumber == 2) {
+            SceneManager.LoadScene("Final Cutscene");
+        }
     }
 
     public void pauseGame()

--- a/Gameheads-SAP-2024/Assets/Scripts/Managers/LevelUIManager.cs
+++ b/Gameheads-SAP-2024/Assets/Scripts/Managers/LevelUIManager.cs
@@ -79,7 +79,7 @@ public class LevelUIManager : MonoBehaviour
         }
         if (levelNumber == 1)
         {
-            SceneManager.LoadScene("Proto Level 2")
+            SceneManager.LoadScene("Proto Level 2");
         }
         else if (levelNumber == 2) {
             SceneManager.LoadScene("Final Cutscene");

--- a/Gameheads-SAP-2024/ProjectSettings/EditorBuildSettings.asset
+++ b/Gameheads-SAP-2024/ProjectSettings/EditorBuildSettings.asset
@@ -26,4 +26,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Revamping Level 1.unity
     guid: 04f7b4c6599b9fa46b446f91148cb98c
+  - enabled: 1
+    path: Assets/Scenes/Proto Level 2.unity
+    guid: 624caa8c9478a8547b5e1543a206b309
   m_configObjects: {}


### PR DESCRIPTION
Level 2 now plays after level 1 is completed
- Add "int level number" field in LevelUIManager.cs <-- this is just the number of the level
- handleVictory() goes to different scenes based on this int
- the try again button on the loss screen now resets the current level instead of calling startgame() (which would start the player over from the first level)
- Added Level 2 to build settings

Suggestions etc:
- Level 2's win condition is still collecting 6 mo'os even though there are more in the level, this should be updated
- We can have a button in Level 2 that immediately takes the player to the final cutscene (skips level) <-- maybe add this button to the loss canvas of level 2 as well
- We can have Level 2 be a hidden level that can be accessed from the credits scene